### PR TITLE
added additionalInfo and updateSuscription method

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ For more information about this, read https://rnfirebase.io/reference/messaging/
 ## Functions
 
 <dl>
-<dt><a href="#NotificationProvider">NotificationProvider(children, appName, events, environment)</a> ⇒ <code>null</code> | <code>React.element</code></dt>
+<dt><a href="#NotificationProvider">NotificationProvider(children, appName, events, environment, additionalInfo)</a> ⇒ <code>null</code> | <code>React.element</code></dt>
 <dd><p>It is the main component of the package, it is a HOC that is responsible for handling the logic of subscribing to notifications and receiving messages from the Firebase console. The HOC contains listeners to listen to notifications in the foreground and background, so (unless we cancel the subscription), we will receive notifications from the app even when it is closed.</p>
 </dd>
 <dt><a href="#setupBackgroundMessageHandler">setupBackgroundMessageHandler(callback)</a></dt>
@@ -70,6 +70,10 @@ For more information about this, read https://rnfirebase.io/reference/messaging/
 <td>This util is responsible for making the request to unsubscribe from all notification events. If no arguments are received, the request will be made with the previously registered events.</td>
 </tr>
 <tr>
+<td>updateSuscription</td>
+<td>This function is responsible for updating the subscription to the notification service</td>
+</tr>
+<tr>
 <td>addNewEvent</td>
 <td>This function allows you to add a new event to receive notifications.</td>
 </tr>
@@ -87,7 +91,7 @@ For more information about this, read https://rnfirebase.io/reference/messaging/
 
 <a name="NotificationProvider"></a>
 
-## NotificationProvider(children, appName, events, environment) ⇒ <code>null</code> \| <code>React.element</code>
+## NotificationProvider(children, appName, events, environment, additionalInfo) ⇒ <code>null</code> \| <code>React.element</code>
 It is the main component of the package, it is a HOC that is responsible for handling the logic of subscribing to notifications and receiving messages from the Firebase console. The HOC contains listeners to listen to notifications in the foreground and background, so (unless we cancel the subscription), we will receive notifications from the app even when it is closed.
 
 **Kind**: global function  
@@ -102,6 +106,7 @@ It is the main component of the package, it is a HOC that is responsible for han
 | appName | <code>string</code> | name of the aplication |
 | events | <code>Array.&lt;string&gt;</code> | is an array that will contain the events to which the user wants to subscribe |
 | environment | <code>string</code> | The environment is necessary for the API that we are going to use to subscribe the device to notifications. |
+| additionalInfo | <code>object</code> | fields to be sent as part of the body of the subscription request |
 
 **Example**  
 ```js
@@ -139,6 +144,7 @@ is a hook, which returns the elements contained within the notifications context
  | backgroundNotification | An object containing all data received when a background push notification is triggered. |
  | subscribeError | An object containing all data received from a notification service subscription failure. |
  | cancelNotifications | This util is responsible for making the request to unsubscribe from all notification events. If no arguments are received, the request will be made with the previously registered events. |
+ | updateSuscription | This function is responsible for updating the subscription to the notification service |
  | addNewEvent | This function allows you to add a new event to receive notifications. |
  | deleteReceivedNotification | An util that clears the foreground or background notification state to the depending on the type it receives by parameter
  | getSubscribedEvents | This function returns an array with the events to which the user is subscribed. |

--- a/lib/NotificationContext.js
+++ b/lib/NotificationContext.js
@@ -18,6 +18,7 @@ export const NotificationContext = React.createContext(null);
  *  | backgroundNotification | An object containing all data received when a background push notification is triggered. |
  *  | subscribeError | An object containing all data received from a notification service subscription failure. |
  *  | cancelNotifications | This util is responsible for making the request to unsubscribe from all notification events. If no arguments are received, the request will be made with the previously registered events. |
+ *  | updateSuscription | This function is responsible for updating the subscription to the notification service |
  *  | addNewEvent | This function allows you to add a new event to receive notifications. |
  *  | deleteReceivedNotification | An util that clears the foreground or background notification state to the depending on the type it receives by parameter
  *  | getSubscribedEvents | This function returns an array with the events to which the user is subscribed. |

--- a/lib/NotificationProvider/index.js
+++ b/lib/NotificationProvider/index.js
@@ -17,6 +17,7 @@ import usePushNotification from '../usePushNotification';
  * @param {string} appName name of the aplication
  * @param {Array<string>} events is an array that will contain the events to which the user wants to subscribe
  * @param {string} environment The environment is necessary for the API that we are going to use to subscribe the device to notifications.
+ * @param {object} additionalInfo fields to be sent as part of the body of the subscription request
  * @throws null when not receive a children argument
  * @returns {null | React.element}
  * @example
@@ -34,7 +35,13 @@ import usePushNotification from '../usePushNotification';
  * )
  */
 
-const NotificationProvider = ({children, appName, events, environment}) => {
+const NotificationProvider = ({
+  children,
+  appName,
+  events,
+  environment,
+  additionalInfo,
+}) => {
   if (!children) return null;
 
   const validAppName = !!appName && isString(appName) ? appName : '';
@@ -53,6 +60,7 @@ const NotificationProvider = ({children, appName, events, environment}) => {
     validEvents,
     validAppName,
     isRegistered,
+    additionalInfo,
   );
 
   // @function handlerForegroundData

--- a/lib/usePushNotification.js
+++ b/lib/usePushNotification.js
@@ -4,7 +4,13 @@ import {getFCMToken, isArray, isString} from './utils';
 import SubscribeNotifications from './utils/api/SubscribeNotifications';
 import UnSubscribeNotifications from './utils/api/UnSubscribeNotifications';
 
-const usePushNotification = (environment, events, appName, isRegistered) => {
+const usePushNotification = (
+  environment,
+  events,
+  appName,
+  isRegistered,
+  additionalInfo,
+) => {
   const [notificationState, setNotificationState] = useState({
     deviceToken: null,
     foregroundNotification: {},
@@ -54,6 +60,7 @@ const usePushNotification = (environment, events, appName, isRegistered) => {
         events: pushEvents,
         deviceToken: token,
         request: Request,
+        additionalInfo,
       });
 
       isRegistered.current = true;
@@ -62,6 +69,31 @@ const usePushNotification = (environment, events, appName, isRegistered) => {
       return updateNotificationState({pushEvents: [], subscribeError: error});
     }
   }, [pushEvents]);
+
+  /**
+   * @function updateSuscription
+   * @description This function is responsible for updating the subscription to the notification service
+   * @param {object} props all properties that will be sent as additional data in the subscription
+   * @returns {Promise}
+   */
+
+  const updateSuscription = async (props = {}) => {
+    try {
+      const token = await getDeviceToken();
+
+      const response = await SubscribeNotifications({
+        appName,
+        events: pushEvents,
+        deviceToken: token,
+        request: Request,
+        additionalInfo: props,
+      });
+
+      return response;
+    } catch (error) {
+      return Promise.reject(error);
+    }
+  };
 
   /**
    * @function cancelNotifications
@@ -161,6 +193,7 @@ const usePushNotification = (environment, events, appName, isRegistered) => {
     updateNotificationState,
     getSubscribedEvents,
     deleteReceivedNotification,
+    updateSuscription,
   };
 };
 

--- a/lib/utils/api/SubscribeNotifications/index.js
+++ b/lib/utils/api/SubscribeNotifications/index.js
@@ -1,11 +1,11 @@
-import {isString, isArray} from '../../index';
+import {isString, isArray, isObject} from '../../index';
 
 const SubscribeNotifications = async (params = {}) => {
   try {
     if (!params || !Object.keys(params).length)
       throw new Error('params is not a valid object');
 
-    const {deviceToken, events, appName, request} = params;
+    const {deviceToken, events, appName, request, additionalInfo} = params;
 
     if (!deviceToken || !isString(deviceToken))
       throw new Error('device token is invalid or null');
@@ -19,10 +19,16 @@ const SubscribeNotifications = async (params = {}) => {
     if (!parsedEvents.length)
       throw new Error('events to be suscribed are invalids');
 
+    const validAdditionalInfo =
+      isObject(additionalInfo) && !!Object.keys(additionalInfo).length;
+
     const body = {
       token: deviceToken,
       events: parsedEvents,
       platformApplicationName: appName,
+      ...(validAdditionalInfo && {
+        additionalInfo,
+      }),
     };
 
     const response = await request.post({

--- a/test/utils/api/subscribeNotifications/index.test.js
+++ b/test/utils/api/subscribeNotifications/index.test.js
@@ -70,7 +70,12 @@ describe('SubscribeNotifications', () => {
 
       nock(server).post('/subscribe/push').reply(200, {});
 
-      const response = await SubscribeNotifications(validParams);
+      const response = await SubscribeNotifications({
+        ...validParams,
+        additionalInfo: {
+          language: 'en-US',
+        },
+      });
 
       expect(response).toStrictEqual({result: {}});
     });


### PR DESCRIPTION
**LINK DE TICKET:**
https://janiscommerce.atlassian.net/browse/APPSRN-315

**LINK DE SUBTAREA:**
https://janiscommerce.atlassian.net/browse/APPSRN-317

**DESCRIPCIÓN DEL REQUERIMIENTO:**

**Contexto**

Contamos con el [pkg](https://github.com/janis-commerce/app-push-notification) para administrar las notificaciones en cada app y esta faltando que el mismo, pueda recibir informacion adiciones como tambien canales a usar en las subscripciones. Los canales nos permite poder mostrar las notificaciones cuando la app esta en segundo plano y la informacion adicional, es necesaria para poder enviar las notificaciones segun ciertos criterios. 

Por ejemplo, un dato adicional que hay que enviar ante cada suscripcion seria el warehouse activo para que el usuario estando en Palermo, no reciba notificaciones que correspondan a una sesion de Belgrano

**Necesidad**

Que el provider del pkg, reciba información adicional y canales. En caso de recibirlos, debe subscribirse con dicha informacion

**DESCRIPCIÓN DE LA SOLUCIÓN:**

Se agregó, en el `NotificationProvider`, una prop más que es `additionalInfo`. Esta prop espera un objeto que se usará dentro del body para la suscripción al servicio de notificaciones.

Además, se hizo una nueva util que se puede obtener desde el hook `usePushNotification` que es `updateSuscription`.  Esta util le pega a la api de suscripción para actualizar la data y también puede recibir un objeto que se enviará como parte de la información a actualizar (Esto va a servir para, por ejemplo, actualizar la data del lenguaje para las notificaciones que se enviará al usuario).

**¿CÓMO SE PUEDE PROBAR?**

Para facilitar la prueba, esto va a convenir hacerlo en picking porque su evento en beta ya está preparado.

Hay que vincular el package con yalc y después `npm install` (`-f` si es necesario)

Luego, en la main, hay que agregar al `NotificationProvider` la prop **additionalInfo** :

```
<NotificationProvider
			appName="PickingApp"
			environment={JANIS_ENV}
			events={eventsToSuscribe}
			additionalInfo={{
				language: selectedLanguage,
					}}>
```

Esta configuración es la que, cuando se realice la sucripción, back usará para asignar el idioma en que serán enviadas las notificaciones. (En views se puede ver cuáles son los idiomas en los que se puede enviar la notificación https://app.janisdev.in/notification/default-event/edit/6662190b0389e407bb7b7101#translations) 

Ahora, hay que asignarse como picker de una sesión y esperar la notificación y validar que llegue en el idioma que fue seleccionado.

**CAMBIO DE IDIOMA**

Lo otro que habría que probar es cómo impacta el cambio de idioma desde la app en la notificación; Para esto hay que usar la util `updateSuscription` de `usePushNotification`.

Para esto, agregue en la home lo siguiente:

**En el import:**
```js
import { selectUserLanguage } from 'src/redux/account/selectors/selectUserLanguage';
import {usePushNotification} from '@janiscommerce/app-push-notification'
```

Agregar las siguientes constantes dentro de la home:
```js
const selectedLanguage = selectUserLanguage(reduxState);
const {updateSuscription} = usePushNotification()
```

También hay que agregar esta función y este useFocusEffect:
```js
const updateNotificationSubscribe = async () => {
	const [response, error] = await promiseWrapper(updateSuscription({
		language: selectedLanguage,
	}))

	if(error) return null;

	console.log('response', response)
}

	useFocusEffect(
		useCallback(() => {
			updateNotificationSubscribe()
		},[selectedLanguage])
	);
```

Luego de haber hecho todo esto hay que ir al menú de usuario y cambiarse el idioma seleccionado. Una vez hecho esto hay que volver a mandarse una notificación (reasignese la misma sesión que uso en el caso anterior) y corroborar que la notificación llegue en el idioma esperado.

**SCREENSHOTS:**
![Captura desde 2024-06-12 11-54-57](https://github.com/janis-commerce/app-push-notification/assets/75044106/8b59fa70-70a5-4f44-88f9-95849078618e)
