### PR TITLE
Feature/appsrn 318 agregar canales de notificacion

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ For more information about this, read https://rnfirebase.io/reference/messaging/
 ## Functions
 
 <dl>
-<dt><a href="#NotificationProvider">NotificationProvider(children, appName, events, environment)</a> ⇒ <code>null</code> | <code>React.element</code></dt>
+<dt><a href="#NotificationProvider">NotificationProvider(children, appName, events, environment, channelConfigs)</a> ⇒ <code>null</code> | <code>React.element</code></dt>
 <dd><p>It is the main component of the package, it is a HOC that is responsible for handling the logic of subscribing to notifications and receiving messages from the Firebase console. The HOC contains listeners to listen to notifications in the foreground and background, so (unless we cancel the subscription), we will receive notifications from the app even when it is closed.</p>
 </dd>
 <dt><a href="#setupBackgroundMessageHandler">setupBackgroundMessageHandler(callback)</a></dt>
@@ -87,7 +87,7 @@ For more information about this, read https://rnfirebase.io/reference/messaging/
 
 <a name="NotificationProvider"></a>
 
-## NotificationProvider(children, appName, events, environment) ⇒ <code>null</code> \| <code>React.element</code>
+## NotificationProvider(children, appName, events, environment, channelConfigs) ⇒ <code>null</code> \| <code>React.element</code>
 It is the main component of the package, it is a HOC that is responsible for handling the logic of subscribing to notifications and receiving messages from the Firebase console. The HOC contains listeners to listen to notifications in the foreground and background, so (unless we cancel the subscription), we will receive notifications from the app even when it is closed.
 
 **Kind**: global function  
@@ -102,6 +102,7 @@ It is the main component of the package, it is a HOC that is responsible for han
 | appName | <code>string</code> | name of the aplication |
 | events | <code>Array.&lt;string&gt;</code> | is an array that will contain the events to which the user wants to subscribe |
 | environment | <code>string</code> | The environment is necessary for the API that we are going to use to subscribe the device to notifications. |
+| channelConfigs | <code>Array.&lt;(string\|object)&gt;</code> | is the configuration that will be used to create new notification channels |
 
 **Example**  
 ```js

--- a/lib/NotificationProvider/index.js
+++ b/lib/NotificationProvider/index.js
@@ -9,6 +9,11 @@ import {
   isObject,
 } from '../utils';
 import usePushNotification from '../usePushNotification';
+import {
+  makeDefaultChannel,
+  makeNotificationChannels,
+  parseNotificationChannel,
+} from '../utils/channel';
 
 /**
  * @function NotificationProvider
@@ -17,6 +22,7 @@ import usePushNotification from '../usePushNotification';
  * @param {string} appName name of the aplication
  * @param {Array<string>} events is an array that will contain the events to which the user wants to subscribe
  * @param {string} environment The environment is necessary for the API that we are going to use to subscribe the device to notifications.
+ * @param {Array<string | object>} channelConfigs is the configuration that will be used to create new notification channels
  * @throws null when not receive a children argument
  * @returns {null | React.element}
  * @example
@@ -34,13 +40,21 @@ import usePushNotification from '../usePushNotification';
  * )
  */
 
-const NotificationProvider = ({children, appName, events, environment}) => {
+const NotificationProvider = ({
+  children,
+  appName,
+  events,
+  environment,
+  channelConfigs = [],
+}) => {
   if (!children) return null;
 
   const validAppName = !!appName && isString(appName) ? appName : '';
   const validEnvironment =
     !!environment && isString(environment) ? environment : '';
   const validEvents = !!events && isArray(events) ? events : [];
+  const validChannelConfigs =
+    !!channelConfigs && isArray(channelConfigs) ? channelConfigs : [];
 
   const isRegistered = useRef(false);
   const {
@@ -87,12 +101,28 @@ const NotificationProvider = ({children, appName, events, environment}) => {
     return updateNotificationState({backgroundNotification: data});
   };
 
+  const createNotificationChannels = async () => {
+    /* istanbul ignore else */
+    if (validChannelConfigs) {
+      const parsedChannelConfigs = validChannelConfigs
+        ?.map((config) => parseNotificationChannel(config))
+        .filter(Boolean);
+
+      await makeNotificationChannels(parsedChannelConfigs);
+    }
+    await makeDefaultChannel();
+  };
+
   useEffect(() => {
     const alreadySuscribed = isRegistered.current;
     if (environment && appName && !!pushEvents.length && !alreadySuscribed) {
       registerDeviceToNotifications();
     }
   }, [pushEvents]);
+
+  useEffect(() => {
+    createNotificationChannels();
+  }, []);
 
   /* istanbul ignore next */
   useEffect(() => {

--- a/lib/utils/channel/index.js
+++ b/lib/utils/channel/index.js
@@ -1,0 +1,71 @@
+import notifee, {AndroidImportance} from '@notifee/react-native';
+import {isObject, isString} from '..';
+
+export const parseChannelConfiguration = (params = {}) => {
+  if (!params || !isObject(params)) return null;
+
+  const {name, id = '', description = ''} = params;
+
+  if (!name || !isString(name)) return null;
+
+  const isValidDescription = !!description && isString(description);
+  const hasValidId = !!id && isString(id);
+
+  return {
+    name,
+    id: hasValidId ? id : name,
+    importance: AndroidImportance.HIGH,
+    ...(isValidDescription && {
+      description,
+    }),
+  };
+};
+
+export const parseNotificationChannel = (channel) => {
+  const channelType = typeof channel;
+  const allowedConfigs = ['string', 'object'];
+
+  if (!allowedConfigs.includes(channelType)) return null;
+  const channelData = channelType === 'string' ? {name: channel} : channel;
+
+  const parsedChannel = parseChannelConfiguration(channelData);
+
+  return parsedChannel;
+};
+
+/* eslint-disable consistent-return */
+export const makeNotificationChannel = async (channelConfig = {}) => {
+  const {id, name} = channelConfig;
+
+  if (!id || !name || !isString(id) || !isString(name)) return null;
+
+  try {
+    await notifee.createChannel(channelConfig);
+  } catch (error) {
+    return Promise.reject(error);
+  }
+};
+
+/* eslint-disable consistent-return */
+export const makeNotificationChannels = async (channelConfigs) => {
+  try {
+    await notifee.createChannels(channelConfigs);
+  } catch (error) {
+    return Promise.reject(error);
+  }
+};
+
+/* eslint-disable consistent-return */
+export const makeDefaultChannel = async () => {
+  try {
+    const parsedChannel = parseChannelConfiguration({
+      id: 'default_channel',
+      name: 'Common notifications',
+      description: 'Default channel to receive notifications',
+    });
+
+    await makeNotificationChannel(parsedChannel);
+  } catch (error) {
+    return Promise.reject(error);
+  }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@janiscommerce/app-request": "^2.2.0",
+        "@notifee/react-native": "^7.8.2",
         "@react-native-async-storage/async-storage": "^1.18.1",
         "@react-native-firebase/app": "^18.3.1",
         "@react-native-firebase/messaging": "^18.3.1",
@@ -4229,6 +4230,14 @@
       "dev": true,
       "dependencies": {
         "eslint-scope": "5.1.1"
+      }
+    },
+    "node_modules/@notifee/react-native": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/@notifee/react-native/-/react-native-7.8.2.tgz",
+      "integrity": "sha512-VG4IkWJIlOKqXwa3aExC3WFCVCGCC9BA55Ivg0SMRfEs+ruvYy/zlLANcrVGiPtgkUEryXDhA8SXx9+JcO8oLA==",
+      "peerDependencies": {
+        "react-native": "*"
       }
     },
     "node_modules/@react-native-async-storage/async-storage": {
@@ -23258,6 +23267,12 @@
       "requires": {
         "eslint-scope": "5.1.1"
       }
+    },
+    "@notifee/react-native": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/@notifee/react-native/-/react-native-7.8.2.tgz",
+      "integrity": "sha512-VG4IkWJIlOKqXwa3aExC3WFCVCGCC9BA55Ivg0SMRfEs+ruvYy/zlLANcrVGiPtgkUEryXDhA8SXx9+JcO8oLA==",
+      "requires": {}
     },
     "@react-native-async-storage/async-storage": {
       "version": "1.21.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "license": "ISC",
   "dependencies": {
     "@janiscommerce/app-request": "^2.2.0",
+    "@notifee/react-native": "^7.8.2",
     "@react-native-async-storage/async-storage": "^1.18.1",
     "@react-native-firebase/app": "^18.3.1",
     "@react-native-firebase/messaging": "^18.3.1",

--- a/setupTest/jest.setup.js
+++ b/setupTest/jest.setup.js
@@ -40,6 +40,17 @@ jest.mock('@janiscommerce/app-request', () => ({
   })),
 }));
 
+jest.mock('@notifee/react-native', () => ({
+  __esModule: true,
+  default: {
+    createChannel: jest.fn(),
+    createChannels: jest.fn(),
+  },
+  AndroidImportance: {
+    HIGH: 4,
+  },
+}));
+
 jest.mock('react-native-device-info', () => {
   const RNDeviceInfo = jest.requireActual(
     'react-native-device-info/jest/react-native-device-info-mock',

--- a/test/NotificationProvider/index.test.js
+++ b/test/NotificationProvider/index.test.js
@@ -74,13 +74,24 @@ describe('NotificationWrapper', () => {
         useRefSpy.mockReturnValueOnce({current: false});
         spySubscribeNotification.mockResolvedValueOnce({result: {}});
 
-        jest.spyOn(React, 'useEffect').mockImplementationOnce((f) => f());
+        jest
+          .spyOn(React, 'useEffect')
+          .mockImplementationOnce((f) => f())
+          .mockImplementationOnce((f) => f());
 
         testRenderer.create(
           <NotificationProvider
             appName="PickingApp"
             events={['picking', 'notifications', 'janis']}
-            environment="beta">
+            environment="beta"
+            channelConfigs={[
+              'channel',
+              {
+                name: 'common channel 2',
+                id: 'channel_2',
+                description: 'second channel',
+              },
+            ]}>
             <View />
           </NotificationProvider>,
         );
@@ -99,7 +110,10 @@ describe('NotificationWrapper', () => {
         useRefSpy.mockReturnValueOnce({current: false});
         spySubscribeNotification.mockRejectedValueOnce({message: 'error'});
 
-        jest.spyOn(React, 'useEffect').mockImplementationOnce((f) => f());
+        jest
+          .spyOn(React, 'useEffect')
+          .mockImplementationOnce((f) => f())
+          .mockImplementationOnce((f) => f());
 
         spyGetToken.mockReturnValueOnce('fcmToken');
 
@@ -107,7 +121,8 @@ describe('NotificationWrapper', () => {
           <NotificationProvider
             appName="PickingApp"
             events={['picking', 'notifications', 'janis']}
-            environment="beta">
+            environment="beta"
+            channelConfigs={{}}>
             <View />
           </NotificationProvider>,
         );

--- a/test/utils/channel/index.test.js
+++ b/test/utils/channel/index.test.js
@@ -1,0 +1,163 @@
+import notifee from '@notifee/react-native';
+import {promiseWrapper} from '../../../lib/utils';
+import {
+  makeDefaultChannel,
+  makeNotificationChannel,
+  makeNotificationChannels,
+  parseChannelConfiguration,
+  parseNotificationChannel,
+} from '../../../lib/utils/channel';
+
+const validChannel = {
+  id: 'channel_id',
+  name: 'channel',
+  description: 'notification channel',
+};
+
+const mockCreateChannel = jest.spyOn(notifee, 'createChannel');
+const mockCreateChannels = jest.spyOn(notifee, 'createChannels');
+
+describe('channel utils', () => {
+  describe('parseChannelConfiguration', () => {
+    describe('return null when', () => {
+      it('not receive an argument', () => {
+        const response = parseChannelConfiguration();
+
+        expect(response).toBeNull();
+      });
+
+      it('receive invalid object as argument', () => {
+        const response = parseChannelConfiguration('channel');
+
+        expect(response).toBeNull();
+      });
+
+      it('the received object hasnt a name key', () => {
+        const response = parseChannelConfiguration({id: 'channel'});
+
+        expect(response).toBeNull();
+      });
+    });
+
+    describe('return parse object', () => {
+      it('when receive a valid channel configuration', () => {
+        const response = parseChannelConfiguration(validChannel);
+
+        expect(response).toStrictEqual({
+          id: 'channel_id',
+          name: 'channel',
+          description: 'notification channel',
+          importance: 4,
+        });
+      });
+      it('with the same name and id when the object not contains id key', () => {
+        const response = parseChannelConfiguration({name: 'channel'});
+
+        expect(response).toStrictEqual({
+          id: 'channel',
+          name: 'channel',
+          importance: 4,
+        });
+      });
+    });
+  });
+
+  describe('parseNotificationChannel', () => {
+    it('return null when not receive an argument with valid type', () => {
+      const response = parseNotificationChannel(1);
+
+      expect(response).toBeNull();
+    });
+    it('return an object when receive an string or object as argument', () => {
+      const parsedChannel1 = parseNotificationChannel('channel');
+      const parsedChannel2 = parseNotificationChannel(validChannel);
+
+      expect(parsedChannel1).toStrictEqual({
+        name: 'channel',
+        id: 'channel',
+        importance: 4,
+      });
+
+      expect(parsedChannel2).toStrictEqual({
+        id: 'channel_id',
+        name: 'channel',
+        description: 'notification channel',
+        importance: 4,
+      });
+    });
+  });
+
+  describe('makeNotificationChannel', () => {
+    describe('return null when', () => {
+      it('receive an object without id or name', async () => {
+        const response = await makeNotificationChannel();
+
+        expect(response).toBeNull();
+      });
+    });
+
+    describe('create a channel when', () => {
+      it('has a valid channelConfig', async () => {
+        mockCreateChannel.mockResolvedValueOnce();
+        const [response] = await promiseWrapper(
+          makeNotificationChannel({...validChannel, importance: 4}),
+        );
+
+        await expect(response).toBeUndefined();
+      });
+    });
+
+    describe('return an error when', () => {
+      it('the channel maker fails', async () => {
+        mockCreateChannel.mockRejectedValueOnce('error');
+        const [, error] = await promiseWrapper(
+          makeNotificationChannel({...validChannel, importance: 4}),
+        );
+
+        await expect(error).toStrictEqual('error');
+      });
+    });
+  });
+
+  describe('makeDefaultChannel', () => {
+    describe('return an error when', () => {
+      it('the default channel maker fails', async () => {
+        mockCreateChannel.mockRejectedValueOnce('error');
+
+        const [, error] = await promiseWrapper(makeDefaultChannel());
+
+        await expect(error).toStrictEqual('error');
+      });
+    });
+
+    describe('create default channel', () => {
+      it('when the function is called', async () => {
+        mockCreateChannel.mockResolvedValueOnce();
+
+        const [response] = await promiseWrapper(makeDefaultChannel());
+
+        await expect(response).toBeUndefined();
+      });
+    });
+  });
+
+  describe('makeNotificationChannels', () => {
+    it('create channels when receive array of configs', async () => {
+      mockCreateChannels.mockResolvedValueOnce();
+
+      const [response] = await promiseWrapper(
+        makeNotificationChannels([{...validChannel, importance: 4}]),
+      );
+
+      await expect(response).toBeUndefined();
+    });
+
+    it('return an error when channels maker fails', async () => {
+      mockCreateChannels.mockRejectedValueOnce('error');
+
+      const [, error] = await promiseWrapper(makeNotificationChannels([]));
+
+      await expect(error).toStrictEqual('error');
+    });
+  });
+});


### PR DESCRIPTION
**LINK DE TICKET:**

https://janiscommerce.atlassian.net/browse/APPSRN-315

**LINK DE SUBTAREA:**

https://janiscommerce.atlassian.net/browse/APPSRN-318

**DESCRIPCIÓN DEL REQUERIMIENTO:**

**Contexto**

Contamos con el [pkg](https://github.com/janis-commerce/app-push-notification) para administrar las notificaciones en cada app y esta faltando que el mismo, pueda recibir informacion adiciones como tambien canales a usar en las subscripciones. Los canales nos permite poder mostrar las notificaciones cuando la app esta en segundo plano y la informacion adicional, es necesaria para poder enviar las notificaciones segun ciertos criterios. 

Por ejemplo, un dato adicional que hay que enviar ante cada suscripcion seria el warehouse activo para que el usuario estando en Palermo, no reciba notificaciones que correspondan a una sesion de Belgrano

**Necesidad**

Que el provider del pkg, reciba información adicional y canales. En caso de recibirlos, debe subscribirse con dicha informacion

**DESCRIPCIÓN DE LA SOLUCIÓN:**

Se agregó la dependencia [notifee](https://notifee.app/), que es la que permite que se creen los canales de notificación.

Se agregó una nueva prop al componente NotificationProvider, que se llama `channelConfigs`: esta prop espera recibir un array de objetos o strings que representen los canales de notificación que el package deberá crear.

La prop está preparada para recibir un array con strings y/u objetos, pero, en caso de pasarle un objeto, este debe contener **obligatoriamente** una key "name" que reciba un `string` como valor, que será la que se use para crear el canal de notificación.


Además, se armaron utils que son particulares para los canales y que sirven para analizar la información y crear los canales de notificación en base a lo que se reciba a traves de la prop 'channelConfigs'.

También, se agregó la configuración necesaria para crear un canal de notificaciones por default que recibe el nombre de "Commons" y que se crea una vez que se monta el componente.

**DATOS A TENER EN CUENTA:**

Los canales creados sólo son visibles en dispositivos fisicos; aún así, si se envía una notificación a un canal se recibirá la notificación tanto en emuladores como en celulares fisicos.

Todos los canales que sean creados lo harán con el mayor nivel de importancia posible, lo que permitirá que vea notificaciones emergentes en su dispositivo.

**¿CÓMO PROBARLO?:**

Es recomendable probarlo en picking para agilizar la prueba.
Primero se necesita vincular el package y además instalar la dependencia de notifee: https://notifee.app/react-native/docs/installation#1-install-via-npm (la versión debería ser la 7.8.2)

Una vez hecho esto, deberá agregar la nueva prop en dónde se esté usando el provider (el index.js de la pantalla Main) y pasarle un array de strings o de objetos que tengan el siguiente formato:
```js
{
name: string,
id?: string,
description?:string
}
```

El array debe ser incluido al provider en la prop channelConfigs:

```js

const channels = ['session_channel', {name:'canal de prueba', id: 'test_channel',description: 'canal al que enviaré la notificacion'}]

<NotificationProvider
	appName="PickingApp"
	environment={JANIS_ENV}
	events={eventsToSuscribe}
	channelConfigs={channels}> //esta prop
	<MainStack />
</NotificationProvider>
```

Luego de agregar esto, levante la aplicación y después, si está usando un celular fisico con android 8 o mayor, entre en la información de la aplicación y acceda al apartado de notificaciones, en él debería poder ver los canales creados (ver video en las screenshots)

Ahora deberá configurar (en views) el canal al que se deben enviar las notificaciones del evento picker-assigned. Para eso, en https://app.janisdev.in/notification/default-event/edit/6662190b0389e407bb7b7101, agregue el id del canal en el input Notification channel:

Si el elemento que pasó en el array de `channelConfigs` fue un `string`, entonces copie y pegue en el input el `string` tal cual lo escribió.
Si el elemento fue un objeto y tenía una key `id` entonces copie y peguelo en el input.

Ahora, mantenga la aplicación en segundo plano y asignele una sesión a su usuario picker; después de un rato debería llegarle una notificación emergente tal cual se muestra en las screenshots.

También puede hacer la prueba apuntando la notificación al canal `default_channel`

De esta manera habrá logrado probar los canales de notificación.
Si necesita más data de qué son y para qué funciona esto puede ver:

https://janiscommerce.atlassian.net/wiki/spaces/JAPP/pages/2973990913/Las+notificaciones+emergentes+y+la+prioridad
https://janiscommerce.atlassian.net/wiki/spaces/JAPP/pages/2974875651/La+prioridad+los+canales+de+notificaciones+y+sus+configuraciones


**SCREENSHOTS:**


https://github.com/janis-commerce/app-push-notification/assets/75044106/c6ad85c8-6ca1-40fb-bd3d-5fb9ace43bd4

![Screenshot_20240613-150123](https://github.com/janis-commerce/app-push-notification/assets/75044106/23b62479-6b44-4798-8bf9-3f03b1b22550)
![Captura desde 2024-06-12 12-37-27](https://github.com/janis-commerce/app-push-notification/assets/75044106/87e8ea9c-df67-4774-ae66-37cf0d90f47b)
