### PR TITLE
added default configurations for notification channels

### DIFF
--- a/lib/constants/defaultChannelConfigs.js
+++ b/lib/constants/defaultChannelConfigs.js
@@ -1,0 +1,13 @@
+import {AndroidImportance, AndroidVisibility} from '@notifee/react-native';
+
+const DEFAULT_CHANNEL_CONFIGS = {
+  badge: true,
+  importance: AndroidImportance.HIGH,
+  lights: true,
+  sound: 'default',
+  vibration: true,
+  vibrationPattern: [500, 1000, 500, 1000],
+  visibility: AndroidVisibility.PUBLIC,
+};
+
+export default DEFAULT_CHANNEL_CONFIGS;

--- a/lib/utils/channel/index.js
+++ b/lib/utils/channel/index.js
@@ -1,10 +1,11 @@
 import notifee, {AndroidImportance} from '@notifee/react-native';
+import DEFAULT_CHANNEL_CONFIGS from '../../constants/defaultChannelConfigs';
 import {isObject, isString} from '..';
 
 export const parseChannelConfiguration = (params = {}) => {
   if (!params || !isObject(params)) return null;
 
-  const {name, id = '', description = ''} = params;
+  const {name, id = '', description = '', ...restConfigs} = params;
 
   if (!name || !isString(name)) return null;
 
@@ -12,6 +13,8 @@ export const parseChannelConfiguration = (params = {}) => {
   const hasValidId = !!id && isString(id);
 
   return {
+    ...DEFAULT_CHANNEL_CONFIGS,
+    ...restConfigs,
     name,
     id: hasValidId ? id : name,
     importance: AndroidImportance.HIGH,
@@ -59,9 +62,9 @@ export const makeNotificationChannels = async (channelConfigs) => {
 export const makeDefaultChannel = async () => {
   try {
     const parsedChannel = parseChannelConfiguration({
-      id: 'default_channel',
-      name: 'Common notifications',
-      description: 'Default channel to receive notifications',
+      id: 'channel_default',
+      name: 'Operational notifications',
+      description: 'Default channel to receive operational notifications',
     });
 
     await makeNotificationChannel(parsedChannel);

--- a/setupTest/jest.setup.js
+++ b/setupTest/jest.setup.js
@@ -47,7 +47,15 @@ jest.mock('@notifee/react-native', () => ({
     createChannels: jest.fn(),
   },
   AndroidImportance: {
+    MIN: 1,
+    LOW: 2,
+    DEFAULT: 3,
     HIGH: 4,
+  },
+  AndroidVisibility: {
+    PUBLIC: 1,
+    PRIVATE: 0,
+    SECRET: -1,
   },
 }));
 

--- a/test/utils/channel/index.test.js
+++ b/test/utils/channel/index.test.js
@@ -1,4 +1,7 @@
-import notifee from '@notifee/react-native';
+import notifee, {
+  AndroidImportance,
+  AndroidVisibility,
+} from '@notifee/react-native';
 import {promiseWrapper} from '../../../lib/utils';
 import {
   makeDefaultChannel,
@@ -7,6 +10,7 @@ import {
   parseChannelConfiguration,
   parseNotificationChannel,
 } from '../../../lib/utils/channel';
+import DEFAULT_CHANNEL_CONFIGS from '../../../lib/constants/defaultChannelConfigs';
 
 const validChannel = {
   id: 'channel_id',
@@ -44,6 +48,7 @@ describe('channel utils', () => {
         const response = parseChannelConfiguration(validChannel);
 
         expect(response).toStrictEqual({
+          ...DEFAULT_CHANNEL_CONFIGS,
           id: 'channel_id',
           name: 'channel',
           description: 'notification channel',
@@ -54,10 +59,39 @@ describe('channel utils', () => {
         const response = parseChannelConfiguration({name: 'channel'});
 
         expect(response).toStrictEqual({
+          ...DEFAULT_CHANNEL_CONFIGS,
           id: 'channel',
           name: 'channel',
           importance: 4,
         });
+      });
+    });
+
+    it('creates a channel that replaces all default values', () => {
+      const response = parseChannelConfiguration({
+        id: 'channel_id',
+        name: 'channel',
+        description: 'notification channel',
+        importance: AndroidImportance.LOW,
+        vibration: false,
+        lights: false,
+        sound: undefined,
+        vibrationPattern: [1000],
+        visibility: AndroidVisibility.PRIVATE,
+      });
+
+      console.log('response', response);
+
+      expect(response).toStrictEqual({
+        ...DEFAULT_CHANNEL_CONFIGS,
+        id: 'channel_id',
+        name: 'channel',
+        description: 'notification channel',
+        vibration: false,
+        lights: false,
+        sound: undefined,
+        vibrationPattern: [1000],
+        visibility: AndroidVisibility.PRIVATE,
       });
     });
   });
@@ -73,12 +107,14 @@ describe('channel utils', () => {
       const parsedChannel2 = parseNotificationChannel(validChannel);
 
       expect(parsedChannel1).toStrictEqual({
+        ...DEFAULT_CHANNEL_CONFIGS,
         name: 'channel',
         id: 'channel',
         importance: 4,
       });
 
       expect(parsedChannel2).toStrictEqual({
+        ...DEFAULT_CHANNEL_CONFIGS,
         id: 'channel_id',
         name: 'channel',
         description: 'notification channel',


### PR DESCRIPTION
## LINK DE TICKET: *
https://janiscommerce.atlassian.net/browse/APPSRN-383
## DESCRIPCIÓN DEL REQUERIMIENTO: *

Contexto

A raiz del rollout de Walmart, el cleinte nos comunico que estaba teniendo problemas con las notificaciones y alertas en monitor ya hace un tiempo. El ultimo [HDI](https://janiscommerce.atlassian.net/browse/HDI-2689) explicaba que no siempre sonaban alertas en los monitores de pickup o app de delivery. En el dia de hoy 11/06 tuvimos una call con el cliente y pudimos confirmar con Marcos del lado de walmart que el problema es que las notificaciones push en la aplicacion se ven pero no emiten ningun sonido. Con respecto a las alertas del monitor, nos comento que no esta teniendo problemas.

Revisando el desarrollo de apps, nos dimos cuenta que al momento de configurar y crear el canal default_channel no configuramos que tengan sonido. Esto va a implicar que se necesita crear un nuevo canal que llamaremos operational notifications, con la configuración correcta impactando en las notificaciones push en segundo plano y ademas sumar el sonido en las notificaciones en primer plano.
Necesidad
Las notificaciones en segundo plano deben sonar con el sonido default del usuario y vibrar. Del lado del usuario, podrá configurar según su celular como quiere que suene o vibre

## DESCRIPCIÓN DE LA SOLUCIÓN: *

Se agregaron configuraciones default para todos los canales de las apps, tanto el canal default como los canales personalizados que querramos crear a futuro.
Ahora, el canal por default se llama **operational notifications**, y el id del canal (el que necesitamos para que las notificaciones lleguen a dónde queremos y emitan sonido y vibraciones) es "channel_default". Para saber a qué canal apuntan las notificaciones se puede ver desde https://app.janisdev.in/notification/default-event/browse
Al entrar en cada uno de los eventos se puede saber a qué canal apuntan actualmente.

## CÓMO SE PUEDE PROBAR? *

Vincular el pkg a la app de delivery o de orders. 
Luego, levantar la aplicación y permitir las notificaciones.
Una vez hecho esto se debe dejar la aplicación en segundo plano.

Desde janis views se puede probar las notificaciones de la app de delivery de varias formas:
- crear rutas para el modulo de delivery o de tms.
- Asignar una ruta a tu usuario de driver.
- Anunciar el pickup de una orden.

Para la app de picking se puede probar:
- Creando una nueva ruta.
- Asignando una ronda de picking a tu usuario de picker.

IMPORTANTE:
Para que las notificaciones funcionen es necesario que todas las acciones que se realicen apunten al warehouse que el usuario tiene seleccionado.

## SCREENSHOTS:

https://github.com/user-attachments/assets/c18a2be3-1a87-4f56-aa99-5a884fee0e1e

https://github.com/user-attachments/assets/d5342010-1b7e-452f-8043-3b29334ab07c
